### PR TITLE
Allow host and external to connect to the server

### DIFF
--- a/bin/obviews.py
+++ b/bin/obviews.py
@@ -1485,7 +1485,7 @@ def main():
 		stat.ensure_load()
 
 	# start browser and server
-	with HTTPServer(("localhost", PORT), Handler) as server:
+	with HTTPServer(("0.0.0.0", PORT), Handler) as server:
 		port = server.server_address[1]
 		if DEBUG or serve:
 			print("INFO: listening to http://localhost:%d" % port)


### PR DESCRIPTION
With host name set to "localhost" we cannot access the server from outside the docker container. so we should set it to "0.0.0.0".